### PR TITLE
Migrate from alpine-build to bitbucket CI image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine-build as openssl
+FROM atlassian/default-image:2 as openssl
 RUN wget -O openssl.tar.gz https://www.openssl.org/source/old/1.0.2/openssl-1.0.2l.tar.gz
 RUN mkdir openssl
 RUN tar -xzf openssl.tar.gz -C openssl --strip-components 1
@@ -9,7 +9,7 @@ RUN patch openssl/ssl/s3_srvr.c s3_srvr.patch
 ADD e_aes_cbc_hmac_sha1.patch e_aes_cbc_hmac_sha1.patch
 RUN patch openssl/crypto/evp/e_aes_cbc_hmac_sha1.c e_aes_cbc_hmac_sha1.patch
 
-WORKDIR /src/openssl
+WORKDIR /opt/atlassian/bitbucketci/agent/build/openssl
 RUN ./config --prefix=/build/ --openssldir=/build/ no-async 
 RUN make -s && make install_sw -s
 
@@ -17,9 +17,10 @@ FROM scratch
 ARG VERSION
 LABEL "server_type"="damnvulnerableopenssl"
 LABEL "server_version"="1.0"
-COPY --from=openssl /lib/ld-musl-x86_64.so.* \
-  /usr/lib/libstdc++.so.* \
-  /usr/lib/libgcc_s.so.* \
-  /build/lib/*.so.* /lib/
+COPY --from=openssl \
+  /lib/x86_64-linux-gnu/libdl.so.* \
+  /lib/x86_64-linux-gnu/libc.so.* \
+  /lib/x86_64-linux-gnu/
+COPY --from=openssl /lib64/ld-linux-x86-64.so.* /lib64/
 COPY --from=openssl /build/bin/openssl /bin/
 ENTRYPOINT ["openssl", "s_server"]


### PR DESCRIPTION
alpine-build has recently been removed from docker hub. As an alternative, just use the Ubuntu 16-based atlassian bitbucket build image. The resulting image is slightly bigger because musl libc is replaced with the GCC variant, but that should not be an issue.